### PR TITLE
Ignore ENETDOWN

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -5149,6 +5149,7 @@ static int pcap_wait_for_frames_mmap(pcap_t *handle)
 					snprintf(handle->errbuf,
 						PCAP_ERRBUF_SIZE,
 						"The interface went down");
+					continue;
 				} else {
 					pcap_fmt_errmsg_for_errno(handle->errbuf,
 					    PCAP_ERRBUF_SIZE, errno,


### PR DESCRIPTION
Don't return a `PCAP_ERROR` when the interface goes down. This tries to be in line with the intentions that @yuguy had in mind back in 2008 as evidenced in his comments around line 1924.